### PR TITLE
Add example for filesystem graph.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ semantic-net
 Semantic-Net is a small python library to create semantic graphs in JSON.
 Those created datasets can then be visualized with the 3D graph engine.
 
+### Installation
+The only dependency is networkx
+
+Either do: `pip install networkx`
+
+or: `pip install -r ./requirements.txt`

--- a/README.md
+++ b/README.md
@@ -4,9 +4,30 @@ semantic-net
 Semantic-Net is a small python library to create semantic graphs in JSON.
 Those created datasets can then be visualized with the 3D graph engine.
 
-### Installation
+## Installation
+
+### Dedpendencies
 The only dependency is networkx
 
 Either do: `pip install networkx`
 
 or: `pip install -r ./requirements.txt`
+
+### Installation
+#### Set your `$PYTHONPATH`
+Be sure your `$PYTHONPATH` environment variable is set to the folder you keep all your
+python modules in.
+
+e.g., if you keep your Python modules in `~/src/python`, do:
+
+```sh
+export PYTHONPATH=.:$HOME/src/python
+```
+
+and restart your shell.
+
+#### Download/Install
+```sh
+cd /path/to/your/python/modules
+git clone https://github.com/ThibaultReuille/semantic-net.git semanticnet
+```

--- a/SemanticNet.py
+++ b/SemanticNet.py
@@ -19,7 +19,7 @@ class Event:
 
 class Graph:
     def __init__(self, verbose=False):
-        self.g = nx.MultiGraph()
+        self._g = nx.MultiGraph()
         self.edges = {}
 
         self.verbose = verbose
@@ -46,31 +46,31 @@ class Graph:
     def add_node(self, data):   
         id = self.create_node_uid()
         self.log("add_node " + str(data) + " = " + str(id)) 
-        self.g.add_node(id, data)
+        self._g.add_node(id, data)
         return id
 
     def add_edge(self, src, dst, data={}):
-        if self.g.has_node(src) and self.g.has_node(dst):
+        if self._g.has_node(src) and self._g.has_node(dst):
             id = self.create_edge_uid()
             self.log("add_edge " + str(src) + ", " + str(dst) + ", " + str(data) + " = " + str(id))
-            self.g.add_edge(src, dst, id, dict(chain(data.items(), {"id": id}.items())) )
-            self.edges[id] = self.g.edge[src][dst][id]
+            self._g.add_edge(src, dst, id, dict(chain(data.items(), {"id": id}.items())) )
+            self.edges[id] = self._g.edge[src][dst][id]
             return id
         else:
             raise GraphException("Node ID not found, can't create edge.")
 
     def set_node_attribute(self, id, attr_name, value):
-        if self.g.has_node(id):
+        if self._g.has_node(id):
             if attr_name in self.attr_reserved:
                 raise GraphException("Attribute {} is reserved.".format(attr_name))
 
-            self.g.node[id][attr_name] = value
+            self._g.node[id][attr_name] = value
         else:
             raise GraphException("Node id not found, can't set attribute.")
 
     def get_node_attribute(self, id, attr_name):
-        if self.g.has_node(id):
-            return self.g.node[id][attr_name]
+        if self._g.has_node(id):
+            return self._g.node[id][attr_name]
         else:
             raise GraphException("Node ID not found, can't get attribute")
 
@@ -99,14 +99,14 @@ class Graph:
         with open(filename, 'w') as outfile:
             graph = dict()
             graph["meta"] = self.meta
-            graph["nodes"] = [ dict(chain({"id": i}.items(), self.g.node[i].items())) for i in self.g.nodes() ]
+            graph["nodes"] = [ dict(chain({"id": i}.items(), self._g.node[i].items())) for i in self._g.nodes() ]
             graph["edges"] = [ dict(
                 chain(
                     { "src": i, "dst": j, "id": key}.items(),
-                    self.g.edge[i][j][key].items())
+                    self._g.edge[i][j][key].items())
                 )
-                for i, j in self.g.edges()
-                for key in self.g.edge[i][j]
+                for i, j in self._g.edges()
+                for key in self._g.edge[i][j]
             ]
             graph["timeline"] = [ [c.timecode, c.name, c.attributes] for c in self.timeline ]
             json.dump(graph, outfile)
@@ -118,13 +118,13 @@ class Graph:
             self.timeline = graph["timeline"]
 
             for node in graph["nodes"]:
-                self.g.add_node(node["id"], dict([item for item in node.items() if item[0] != 'id']))
+                self._g.add_node(node["id"], dict([item for item in node.items() if item[0] != 'id']))
 
             for edge in graph["edges"]:
-                self.g.add_edge(edge["src"], edge["dst"], dict(item for item in edge.items() if (item[0] != "src" and item[0] != "dst") ))
+                self._g.add_edge(edge["src"], edge["dst"], dict(item for item in edge.items() if (item[0] != "src" and item[0] != "dst") ))
 
-            self.last_node_id = len(self.g.nodes())
-            self.last_edge_id = len(self.g.edges())
+            self.last_node_id = len(self._g.nodes())
+            self.last_edge_id = len(self._g.edges())
 
 if __name__ == "__main__":
     print("Please import this module !")

--- a/SemanticNet.py
+++ b/SemanticNet.py
@@ -44,53 +44,53 @@ class Graph:
         return self.last_edge_id
 
     def add_node(self, data):   
-        id = self.create_node_uid()
-        self.log("add_node " + str(data) + " = " + str(id)) 
-        self._g.add_node(id, data)
-        return id
+        id_ = self.create_node_uid()
+        self.log("add_node " + str(data) + " = " + str(id_))
+        self._g.add_node(id_, data)
+        return id_
 
     def add_edge(self, src, dst, data={}):
         if self._g.has_node(src) and self._g.has_node(dst):
-            id = self.create_edge_uid()
-            self.log("add_edge " + str(src) + ", " + str(dst) + ", " + str(data) + " = " + str(id))
-            self._g.add_edge(src, dst, id, dict(chain(data.items(), {"id": id}.items())) )
-            self.edges[id] = self._g.edge[src][dst][id]
-            return id
+            id_ = self.create_edge_uid()
+            self.log("add_edge " + str(src) + ", " + str(dst) + ", " + str(data) + " = " + str(id_))
+            self._g.add_edge(src, dst, id_, dict(chain(data.items(), {"id": id_}.items())) )
+            self.edges[id_] = self._g.edge[src][dst][id_]
+            return id_
         else:
             raise GraphException("Node ID not found, can't create edge.")
 
-    def set_node_attribute(self, id, attr_name, value):
-        if self._g.has_node(id):
+    def set_node_attribute(self, id_, attr_name, value):
+        if self._g.has_node(id_):
             if attr_name in self.attr_reserved:
                 raise GraphException("Attribute {} is reserved.".format(attr_name))
 
-            self._g.node[id][attr_name] = value
+            self._g.node[id_][attr_name] = value
         else:
             raise GraphException("Node id not found, can't set attribute.")
 
-    def get_node_attribute(self, id, attr_name):
-        if self._g.has_node(id):
-            return self._g.node[id][attr_name]
+    def get_node_attribute(self, id_, attr_name):
+        if self._g.has_node(id_):
+            return self._g.node[id_][attr_name]
         else:
             raise GraphException("Node ID not found, can't get attribute")
 
-    def set_edge_attribute(self, id, attr_name, value):
-        if id in self.edges:
+    def set_edge_attribute(self, id_, attr_name, value):
+        if id_ in self.edges:
             if attr_name in self.attr_reserved:
                 raise GraphException("Attribute {} is reserved.".format(attr_name))
 
-            self.edges[id][attr_name] = value
+            self.edges[id_][attr_name] = value
         else:
-            raise GraphException("Edge id '" + str(id) + "' not found!")
+            raise GraphException("Edge id '" + str(id_) + "' not found!")
 
-    def get_edge_attribute(self, id, attr_name):
-        if id in self.edges:
-            if attr_name in self.edges[id]:
-                return self.edges[id][attr_name]
+    def get_edge_attribute(self, id_, attr_name):
+        if id_ in self.edges:
+            if attr_name in self.edges[id_]:
+                return self.edges[id_][attr_name]
             else:
                 return None
         else:
-            raise GraphException("Edge id '" + str(id) + "' not found!")
+            raise GraphException("Edge id '" + str(id_) + "' not found!")
 
     def add_event(self, timecode, name, attributes):
         self.timeline.append(Event(timecode, name, attributes))

--- a/examples/fs_graph.py
+++ b/examples/fs_graph.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import argparse
+import semanticnet.SemanticNet as sn
+
+if __name__ == "__main__":
+    if len(sys.argv) < 1:
+        print("Need a starting dir")
+        sys.exit(-1)
+
+    start = sys.argv[1]
+
+    nodesByName = {}
+    graph = sn.Graph()
+    cur = graph.add_node({"label": start, "type": "dir", "depth": 0})
+    nodesByName[start] = cur
+
+    def add_node(root, label, node_type):
+        data = {}
+        node = None
+        path = ""
+
+        if os.path.islink(root):
+            root = os.path.realpath(root)
+
+        path = os.path.join(root, label)
+
+        if path in nodesByName:
+            node = nodesByName[path]
+        else:
+            node = graph.add_node({"type": node_type, "label": label})
+            nodesByName[path] = node
+
+        if os.path.islink(path):
+            data = {"type": "link"}
+
+        graph.add_edge(cur, node, data)
+
+    for root, dirs, files in os.walk(start, followlinks=True):
+        print(root)
+
+        if root in nodesByName:
+            cur = nodesByName[root] 
+        else:    
+            cur = graph.add_node({"label": root, "type": "dir"})
+            nodesByName[root] = cur
+
+        for d in dirs:
+            add_node(root, d, "dir")
+        for f in files:
+            add_node(root, f, os.path.splitext(f)[1])
+
+    graph.save_json("fs.json")

--- a/examples/fs_graph.py
+++ b/examples/fs_graph.py
@@ -23,6 +23,7 @@ if __name__ == "__main__":
         path = ""
 
         if os.path.islink(root):
+            data = {"type": "link"}
             root = os.path.realpath(root)
 
         path = os.path.join(root, label)
@@ -32,9 +33,6 @@ if __name__ == "__main__":
         else:
             node = graph.add_node({"type": node_type, "label": label})
             nodesByName[path] = node
-
-        if os.path.islink(path):
-            data = {"type": "link"}
 
         graph.add_edge(cur, node, data)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+networkx


### PR DESCRIPTION
- Use UUIDs for node and edge IDs.
- Add example for filesystem graph
- Update installation instructions in the README
- Refactor variables
  - make the underlying networkx graph private
  - rename `id` variables to `id_` (per PEP8) to avoid conflict with the built-in `id()` method
