### PR TITLE
String IDs, remove methods, docs, unit tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *.json
+*.DS_Store
+*__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.json
 *.DS_Store
 *__pycache__
+*.coverage

--- a/README.md
+++ b/README.md
@@ -31,3 +31,16 @@ and restart your shell.
 cd /path/to/your/python/modules
 git clone https://github.com/ThibaultReuille/semantic-net.git semanticnet
 ```
+
+#### Tests
+If you wish to run the test suite, it uses `py.test`. Install it with:
+
+```sh
+pip install pytest
+```
+
+and run the tests with:
+
+```sh
+py.test -v ./test/test_semanticnet.py
+```

--- a/SemanticNet.py
+++ b/SemanticNet.py
@@ -54,9 +54,19 @@ class Graph:
         self._g.add_node(id_, data)
         return id_
 
-    def __remove_node(self, id_):
-        '''TODO: Remove node id_'''
-        pass
+    def remove_node(self, id_):
+        '''Removes node id_.'''
+        id_ = self._extract_uuid(id_)
+        if self._g.has_node(id_):
+            for neighbor in self._g.neighbors(id_):
+                # need to iterate over items() (which copies the dict) because we are
+                # removing items from the edges dict as we are iterating over it
+                for edge in self._g.edge[id_][neighbor].items():
+                    # edge[0] is the edge's ID
+                    self.remove_edge(self._g.edge[id_][neighbor][edge[0]]["id"])
+            self._g.remove_node(id_)
+        else:
+            raise GraphException("Node ID not found.")
 
     def add_edge(self, src, dst, data={}, id_=None):
         src = self._extract_uuid(src)
@@ -83,9 +93,15 @@ class Graph:
         else:
             raise GraphException("Node ID not found.")
 
-    def __remove_edge(self, id_):
-        '''TODO: Remove edge id_.'''
-        pass
+    def remove_edge(self, id_):
+        '''Removes edge id_.'''
+        id_ = self._extract_uuid(id_)
+        if id_ in self.edges:
+            edge = self.edges[id_]
+            self._g.remove_edge(edge["src"], edge["dst"], id_)
+            del self.edges[id_]
+        else:
+            raise GraphException("Node ID not found.")
 
     def set_node_attribute(self, id_, attr_name, value):
         id_ = self._extract_uuid(id_)

--- a/SemanticNet.py
+++ b/SemanticNet.py
@@ -59,6 +59,7 @@ class Graph:
         else:
             id_ = self._extract_uuid(id_)
 
+        data['id'] = id_ # add the ID to the attributes
         self.log("add_node " + str(data) + " = " + str(id_))
         self._g.add_node(id_, data)
         return id_
@@ -198,7 +199,7 @@ class Graph:
         with open(filename, 'w') as outfile:
             graph = dict()
             graph["meta"] = self.meta
-            graph["nodes"] = [ dict(chain({"id": id_.hex}.items(), self._g.node[id_].items())) for id_ in self._g.nodes() ]
+            graph["nodes"] = [ dict(chain(self._g.node[id_].items(), {"id": id_.hex}.items())) for id_ in self._g.nodes() ]
             graph["edges"] = [
                 dict(
                     chain(

--- a/SemanticNet.py
+++ b/SemanticNet.py
@@ -23,7 +23,7 @@ class Graph:
 
     def __init__(self, verbose=False):
         self._g = nx.MultiGraph()
-        self.edges = {}
+        self._edges = {}
         self.meta = {}
         self.timeline = []
 
@@ -33,7 +33,7 @@ class Graph:
     def _create_uuid(self):
         '''Create a random UUID for a new node or edge. Checks for collisions.'''
         id_ = uuid.uuid4()
-        while self._g.has_node(id_) or id_ in self.edges:
+        while self._g.has_node(id_) or id_ in self._edges:
             id_ = uuid.uuid4()
         return id_
 
@@ -101,7 +101,7 @@ class Graph:
                     }.items())
                 )
             )
-            self.edges[id_] = self._g.edge[src][dst][id_]
+            self._edges[id_] = self._g.edge[src][dst][id_]
             return id_
         else:
             raise GraphException("Node ID not found.")
@@ -109,10 +109,10 @@ class Graph:
     def remove_edge(self, id_):
         '''Removes edge id_.'''
         id_ = self._extract_uuid(id_)
-        if id_ in self.edges:
-            edge = self.edges[id_]
+        if id_ in self._edges:
+            edge = self._edges[id_]
             self._g.remove_edge(edge["src"], edge["dst"], id_)
-            del self.edges[id_]
+            del self._edges[id_]
         else:
             raise GraphException("Node ID not found.")
 
@@ -150,41 +150,41 @@ class Graph:
 
     def get_edges(self):
         '''Returns all edges in the graph.'''
-        return self.edges
+        return self._edges
 
     def get_edge(self, id_):
         '''Returns edge id_.'''
         id_ = self._extract_uuid(id_)
-        if id_ in self.edges:
-            return self.edges[id_]
+        if id_ in self._edges:
+            return self._edges[id_]
         else:
             raise GraphException('Node ID not found.')
 
     def set_edge_attribute(self, id_, attr_name, value):
         '''Sets the attribute attr_name to value for edge id_.'''
         id_ = self._extract_uuid(id_)
-        if id_ in self.edges:
+        if id_ in self._edges:
             if attr_name in self.attr_reserved:
                 raise GraphException("Attribute {} is reserved.".format(attr_name))
 
-            self.edges[id_][attr_name] = value
+            self._edges[id_][attr_name] = value
         else:
             raise GraphException("Edge id '" + str(id_) + "' not found!")
 
     def get_edge_attributes(self, id_):
         '''Returns all attributes for edge id_.'''
         id_ = self._extract_uuid(id_)
-        if id_ in self.edges:
-            return self.edges[id_]
+        if id_ in self._edges:
+            return self._edges[id_]
         else:
             raise GraphException("Edge id '" + str(id_) + "' not found!")
 
     def get_edge_attribute(self, id_, attr_name):
         '''Returns the attribute attr_name for edge id_.'''
         id_ = self._extract_uuid(id_)
-        if id_ in self.edges:
-            if attr_name in self.edges[id_]:
-                return self.edges[id_][attr_name]
+        if id_ in self._edges:
+            if attr_name in self._edges[id_]:
+                return self._edges[id_][attr_name]
             else:
                 return None
         else:

--- a/SemanticNet.py
+++ b/SemanticNet.py
@@ -19,6 +19,8 @@ class Event:
         self.attributes = attributes
 
 class Graph:
+    '''A simple Graph structure which lets you focus on the data.'''
+
     def __init__(self, verbose=False):
         self._g = nx.MultiGraph()
         self.edges = {}
@@ -29,22 +31,29 @@ class Graph:
         self.attr_reserved = ["id", "src", "dst"]
 
     def _create_uuid(self):
+        '''Create a random UUID for a new node or edge. Checks for collisions.'''
         id_ = uuid.uuid4()
         while self._g.has_node(id_) or id_ in self.edges:
             id_ = uuid.uuid4()
         return id_
 
     def _extract_uuid(self, id_):
+        '''Parse a UUID out of the string id_.'''
         if id_.__class__.__name__ == 'UUID':
             return id_
 
         return uuid.UUID(id_)
 
     def log(self, line):
+        '''Print the message line to standard output.'''
         if self.verbose:
             print("[SemanticNet] " + line)
 
     def add_node(self, data={}, id_=None):
+        '''Add a node to the graph, with an optional dict of attributes, data.
+        Although you can specify your own id with id_, it is recommended NOT
+        to do this, to avoid unintentional collisions and/or data loss.
+        '''
         if id_ == None:
             id_ = self._create_uuid()
         else:
@@ -69,6 +78,10 @@ class Graph:
             raise GraphException("Node ID not found.")
 
     def add_edge(self, src, dst, data={}, id_=None):
+        '''Add an edge from src to dst, with an optional dict of attributes, data.
+        Although you can specify your own id with id_, it is recommended NOT
+        to do this, to avoid unintentional collisions and/or data loss.
+        '''
         src = self._extract_uuid(src)
         dst = self._extract_uuid(dst)
 
@@ -104,6 +117,7 @@ class Graph:
             raise GraphException("Node ID not found.")
 
     def set_node_attribute(self, id_, attr_name, value):
+        '''Sets the attribute attr_name to value for node id_.'''
         id_ = self._extract_uuid(id_)
 
         if self._g.has_node(id_):
@@ -115,9 +129,11 @@ class Graph:
             raise GraphException("Node id not found, can't set attribute.")
 
     def get_nodes(self):
+        '''Returns a list of all nodes in the graph.'''
         return self._g.nodes()
 
     def get_node_attribute(self, id_, attr_name):
+        '''Returns the attribute attr_name of node id_.'''
         id_ = self._extract_uuid(id_)
         if self._g.has_node(id_):
             return self._g.node[id_][attr_name]
@@ -125,6 +141,7 @@ class Graph:
             raise GraphException("Node ID not found, can't get attribute")
 
     def get_node_attributes(self, id_):
+        '''Returns all attributes of node id_.'''
         id_ = self._extract_uuid(id_)
         if self._g.has_node(id_):
             return self._g.node[id_]
@@ -132,9 +149,11 @@ class Graph:
             raise GraphException("Node ID not found, can't get attribute")
 
     def get_edges(self):
+        '''Returns all edges in the graph.'''
         return self.edges
 
     def get_edge(self, id_):
+        '''Returns edge id_.'''
         id_ = self._extract_uuid(id_)
         if id_ in self.edges:
             return self.edges[id_]
@@ -142,6 +161,7 @@ class Graph:
             raise GraphException('Node ID not found.')
 
     def set_edge_attribute(self, id_, attr_name, value):
+        '''Sets the attribute attr_name to value for edge id_.'''
         id_ = self._extract_uuid(id_)
         if id_ in self.edges:
             if attr_name in self.attr_reserved:
@@ -152,6 +172,7 @@ class Graph:
             raise GraphException("Edge id '" + str(id_) + "' not found!")
 
     def get_edge_attributes(self, id_):
+        '''Returns all attributes for edge id_.'''
         id_ = self._extract_uuid(id_)
         if id_ in self.edges:
             return self.edges[id_]
@@ -159,6 +180,7 @@ class Graph:
             raise GraphException("Edge id '" + str(id_) + "' not found!")
 
     def get_edge_attribute(self, id_, attr_name):
+        '''Returns the attribute attr_name for edge id_.'''
         id_ = self._extract_uuid(id_)
         if id_ in self.edges:
             if attr_name in self.edges[id_]:
@@ -172,6 +194,7 @@ class Graph:
         self.timeline.append(Event(timecode, name, attributes))
 
     def save_json(self, filename):
+        '''Exports the graph to a JSON file for use in the Gaia visualizer.'''
         with open(filename, 'w') as outfile:
             graph = dict()
             graph["meta"] = self.meta
@@ -194,6 +217,7 @@ class Graph:
             json.dump(graph, outfile, indent=True)
 
     def load_json(self, filename):
+        '''Generates a graph from the JSON file filename.'''
         with open(filename, 'r') as infile:
             graph = json.load(infile)
             self.meta = graph["meta"]

--- a/SemanticNet.py
+++ b/SemanticNet.py
@@ -130,7 +130,7 @@ class Graph:
 
     def get_nodes(self):
         '''Returns a list of all nodes in the graph.'''
-        return self._g.nodes()
+        return dict([ (id_, self._g.node[id_]) for id_ in self._g.nodes() ])
 
     def get_node_attribute(self, id_, attr_name):
         '''Returns the attribute attr_name of node id_.'''

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from SemanticNet import *

--- a/examples/fs_graph.py
+++ b/examples/fs_graph.py
@@ -3,7 +3,7 @@
 import sys
 import os
 import argparse
-import semanticnet.SemanticNet as sn
+import semanticnet as sn
 
 if __name__ == "__main__":
     if len(sys.argv) < 1:

--- a/test/test_output_correct.json
+++ b/test/test_output_correct.json
@@ -1,0 +1,38 @@
+{
+ "timeline": [], 
+ "nodes": [
+  {
+   "id": "d6523f4f9d5240d2a92e341f4ca00a78", 
+   "label": "C"
+  }, 
+  {
+   "id": "bcb388bb24a74d978fa2006ed278b2fe", 
+   "label": "B"
+  }, 
+  {
+   "id": "6cf546f71efe47578f7a1400871ef6b8", 
+   "label": "A"
+  }
+ ], 
+ "meta": {}, 
+ "edges": [
+  {
+   "src": "d6523f4f9d5240d2a92e341f4ca00a78", 
+   "dst": "bcb388bb24a74d978fa2006ed278b2fe", 
+   "type": "owns", 
+   "id": "081369f6197b467abe97b3efe8cc4640"
+  }, 
+  {
+   "src": "d6523f4f9d5240d2a92e341f4ca00a78", 
+   "dst": "6cf546f71efe47578f7a1400871ef6b8", 
+   "type": "has", 
+   "id": "b3a245098d5d482f893c6d63606c7e91"
+  }, 
+  {
+   "src": "bcb388bb24a74d978fa2006ed278b2fe", 
+   "dst": "6cf546f71efe47578f7a1400871ef6b8", 
+   "type": "belongs", 
+   "id": "ff8a8a8093cf436aa3b0127c71ddc11d"
+  }
+ ]
+}

--- a/test/test_semanticnet.py
+++ b/test/test_semanticnet.py
@@ -1,0 +1,208 @@
+import pytest
+import semanticnet.SemanticNet as sn
+import uuid
+import os
+
+### FIXTURES ###
+@pytest.fixture
+def uuid_str():
+    return '3caaa8c09148493dbdf02c574b95526c'
+
+@pytest.fixture
+def uuid_obj():
+    return uuid.UUID('3caaa8c09148493dbdf02c574b95526c')
+
+@pytest.fixture
+def graph():
+    return sn.Graph()
+
+@pytest.fixture
+def populated_graph():
+    g = sn.Graph()
+    a = g.add_node({"type": "A"}, '3caaa8c09148493dbdf02c574b95526c')
+    b = g.add_node({"type": "B"}, '2cdfebf3bf9547f19f0412ccdfbe03b7')
+    c = g.add_node({"type": "C"}, '3cd197c2cf5e42dc9ccd0c2adcaf4bc2')
+    g.add_edge(a, b, {"type": "normal"}, '5f5f44ec7c0144e29c5b7d513f92d9ab')
+    g.add_edge(a, c, {"type": "normal"}, '7eb91be54d3746b89a61a282bcc207bb')
+    g.add_edge(b, c, {"type": "irregular"}, 'c172a3599b7d4ef3bbb688277276b763')
+    return g
+
+@pytest.fixture
+def test_output():
+    graph = sn.Graph()
+
+    a = graph.add_node({"label" : "A"}, '6cf546f71efe47578f7a1400871ef6b8')
+    b = graph.add_node({"label" : "B"}, 'bcb388bb24a74d978fa2006ed278b2fe')
+    c = graph.add_node({"label" : "C"}, 'd6523f4f9d5240d2a92e341f4ca00a78')
+
+    graph.add_edge(a, b, {"type" : "belongs"}, 'ff8a8a8093cf436aa3b0127c71ddc11d')
+    graph.add_edge(b, c, {"type" : "owns"}, '081369f6197b467abe97b3efe8cc4640')
+    graph.add_edge(c, a, {"type" : "has"}, 'b3a245098d5d482f893c6d63606c7e91')
+
+    graph.save_json("test_output.json")
+
+    f_str = ""
+    with open("test_output.json") as f:
+        f_str = f.read()
+    return f_str
+
+@pytest.fixture
+def correct_output():
+    f_str = ""
+    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_output_correct.json")) as f:
+        f_str = f.read()
+    return f_str
+
+@pytest.fixture
+def correct_output_graph():
+    g = sn.Graph()
+    g.load_json(os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_output_correct.json"))
+    return g
+
+### TESTS ###
+def test__create_uuid(graph):
+    id_ = graph._create_uuid()
+    assert id_.__class__.__name__ == 'UUID'
+
+def test__extract_uuid(graph, uuid_str, uuid_obj):
+    assert graph._extract_uuid(uuid_str) == uuid_obj
+
+def test_add_node(graph):
+    a = graph.add_node({"type": "A"})
+
+    nodes = graph.get_nodes()
+    assert a in nodes
+
+    node = graph.get_node_attributes(a)
+    assert "type" in node
+    assert node["type"] == "A"
+
+def test_get_nodes(populated_graph):
+    output = {
+        uuid.UUID('2cdfebf3-bf95-47f1-9f04-12ccdfbe03b7'): {'type': 'B'},
+        uuid.UUID('3caaa8c0-9148-493d-bdf0-2c574b95526c'): {'type': 'A'},
+        uuid.UUID('3cd197c2-cf5e-42dc-9ccd-0c2adcaf4bc2'): {'type': 'C'}
+    }
+    assert populated_graph.get_nodes() == output
+
+def test_get_node_attribute(populated_graph):
+    assert populated_graph.get_node_attribute('3caaa8c09148493dbdf02c574b95526c', 'type') == 'A'
+    assert populated_graph.get_node_attribute('2cdfebf3bf9547f19f0412ccdfbe03b7', 'type') == 'B'
+    assert populated_graph.get_node_attribute('3cd197c2cf5e42dc9ccd0c2adcaf4bc2', 'type') == 'C'
+
+def test_set_node_attribute(populated_graph):
+    populated_graph.set_node_attribute('3caaa8c09148493dbdf02c574b95526c', 'depth', 5)
+    assert populated_graph.get_node_attribute('3caaa8c09148493dbdf02c574b95526c', 'depth') == 5
+    
+    populated_graph.set_node_attribute('3caaa8c09148493dbdf02c574b95526c', 'type', 'D')
+    assert populated_graph.get_node_attribute('3caaa8c09148493dbdf02c574b95526c', 'type') != 'A'
+    assert populated_graph.get_node_attribute('3caaa8c09148493dbdf02c574b95526c', 'type') == 'D'
+
+def test_add_edge(graph):
+    a = graph.add_node({"type": "A"})
+    b = graph.add_node({"type": "B"})
+    e = graph.add_edge(a, b, {"type": "normal"})
+
+    assert len(graph.get_edges()) != 0
+    assert e in graph.get_edges()
+
+    attrs = graph.get_edge_attributes(e)
+    assert "type" in attrs
+    assert attrs["type"] == "normal"
+
+def test_get_edges(populated_graph):
+    output = {
+        uuid.UUID('7eb91be5-4d37-46b8-9a61-a282bcc207bb'): {
+            'src': uuid.UUID('3caaa8c0-9148-493d-bdf0-2c574b95526c'),
+            'dst': uuid.UUID('3cd197c2-cf5e-42dc-9ccd-0c2adcaf4bc2'),
+            'type': 'normal',
+            'id': uuid.UUID('7eb91be5-4d37-46b8-9a61-a282bcc207bb')
+        },
+        uuid.UUID('5f5f44ec-7c01-44e2-9c5b-7d513f92d9ab'): {
+            'src': uuid.UUID('3caaa8c0-9148-493d-bdf0-2c574b95526c'),
+            'dst': uuid.UUID('2cdfebf3-bf95-47f1-9f04-12ccdfbe03b7'),
+            'type': 'normal',
+            'id': uuid.UUID('5f5f44ec-7c01-44e2-9c5b-7d513f92d9ab')
+        },
+        uuid.UUID('c172a359-9b7d-4ef3-bbb6-88277276b763'): {
+            'src': uuid.UUID('2cdfebf3-bf95-47f1-9f04-12ccdfbe03b7'),
+            'dst': uuid.UUID('3cd197c2-cf5e-42dc-9ccd-0c2adcaf4bc2'),
+            'type': 'irregular',
+            'id': uuid.UUID('c172a359-9b7d-4ef3-bbb6-88277276b763')
+        }
+    }
+    assert populated_graph.get_edges() == output
+
+def test_get_edge_attribute(populated_graph):
+    assert populated_graph.get_edge_attribute('5f5f44ec7c0144e29c5b7d513f92d9ab', 'type') == 'normal'
+
+def test_set_edge_attribute(populated_graph):
+    populated_graph.set_edge_attribute('5f5f44ec7c0144e29c5b7d513f92d9ab', 'weight', 5)
+    assert populated_graph.get_edge_attribute('5f5f44ec7c0144e29c5b7d513f92d9ab', 'weight') == 5
+    
+    populated_graph.set_edge_attribute('5f5f44ec7c0144e29c5b7d513f92d9ab', 'type', 'irregular')
+    assert populated_graph.get_edge_attribute('5f5f44ec7c0144e29c5b7d513f92d9ab', 'type') != 'normal'
+    assert populated_graph.get_edge_attribute('5f5f44ec7c0144e29c5b7d513f92d9ab', 'type') == 'irregular'
+
+def test_remove_edge(populated_graph):
+    populated_graph.remove_edge('5f5f44ec7c0144e29c5b7d513f92d9ab')
+    assert uuid.UUID('5f5f44ec7c0144e29c5b7d513f92d9ab') not in populated_graph.get_edges()
+
+def test_remove_node(populated_graph):
+    node_a_id = uuid.UUID('3caaa8c09148493dbdf02c574b95526c')
+    node_b_id = uuid.UUID('2cdfebf3bf9547f19f0412ccdfbe03b7')
+    node_c_id = uuid.UUID('3cd197c2cf5e42dc9ccd0c2adcaf4bc2')
+
+    edge_a_b_id = uuid.UUID('5f5f44ec7c0144e29c5b7d513f92d9ab')
+    edge_a_c_id = uuid.UUID('7eb91be54d3746b89a61a282bcc207bb')
+    edge_b_c_id = uuid.UUID('c172a3599b7d4ef3bbb688277276b763')
+
+    populated_graph.remove_node('3caaa8c09148493dbdf02c574b95526c')
+    
+    # make sure a is gone, and b and c are not
+    assert node_a_id not in populated_graph.get_nodes()
+    assert node_b_id in populated_graph.get_nodes()
+    assert node_c_id in populated_graph.get_nodes()
+
+    # make sure the edges from a to b and a to c are gone
+    # but the edge from b to c is not
+    edges = populated_graph.get_edges()
+    assert edge_a_b_id not in edges
+    assert edge_a_c_id not in edges
+    assert edge_b_c_id in edges
+
+def test_save_json(test_output, correct_output):
+    assert test_output == correct_output
+    os.remove("test_output.json")
+
+def test_load_json(correct_output_graph):
+    nodes = {
+        uuid.UUID('6cf546f71efe47578f7a1400871ef6b8'): {'label': 'A'},
+        uuid.UUID('bcb388bb24a74d978fa2006ed278b2fe'): {'label': 'B'},
+        uuid.UUID('d6523f4f9d5240d2a92e341f4ca00a78'): {'label': 'C'}
+    }
+
+    assert correct_output_graph.get_nodes() == nodes
+
+    edges = {
+        uuid.UUID('081369f6197b467abe97b3efe8cc4640'): {
+            'src': uuid.UUID('d6523f4f9d5240d2a92e341f4ca00a78'),
+            'dst': uuid.UUID('bcb388bb24a74d978fa2006ed278b2fe'),
+            'type': 'owns',
+            'id': uuid.UUID('081369f6197b467abe97b3efe8cc4640')
+        },
+        uuid.UUID('b3a245098d5d482f893c6d63606c7e91'): {
+            'src': uuid.UUID('d6523f4f9d5240d2a92e341f4ca00a78'),
+            'dst': uuid.UUID('6cf546f71efe47578f7a1400871ef6b8'),
+            'type': 'has',
+            'id': uuid.UUID('b3a245098d5d482f893c6d63606c7e91')
+        },
+        uuid.UUID('ff8a8a8093cf436aa3b0127c71ddc11d'): {
+            'src': uuid.UUID('bcb388bb24a74d978fa2006ed278b2fe'),
+            'dst': uuid.UUID('6cf546f71efe47578f7a1400871ef6b8'),
+            'type': 'belongs',
+            'id': uuid.UUID('ff8a8a8093cf436aa3b0127c71ddc11d')
+        }
+    }
+
+    assert correct_output_graph.get_edges() == edges

--- a/test/test_semanticnet.py
+++ b/test/test_semanticnet.py
@@ -89,9 +89,18 @@ def test_add_node(graph):
 
 def test_get_nodes(populated_graph):
     output = {
-        uuid.UUID('2cdfebf3-bf95-47f1-9f04-12ccdfbe03b7'): {'type': 'B'},
-        uuid.UUID('3caaa8c0-9148-493d-bdf0-2c574b95526c'): {'type': 'A'},
-        uuid.UUID('3cd197c2-cf5e-42dc-9ccd-0c2adcaf4bc2'): {'type': 'C'}
+        uuid.UUID('2cdfebf3-bf95-47f1-9f04-12ccdfbe03b7'): {
+            "id": uuid.UUID('2cdfebf3-bf95-47f1-9f04-12ccdfbe03b7'),
+            'type': 'B'
+        },
+        uuid.UUID('3caaa8c0-9148-493d-bdf0-2c574b95526c'): {
+            "id": uuid.UUID('3caaa8c0-9148-493d-bdf0-2c574b95526c'),
+            'type': 'A'
+        },
+        uuid.UUID('3cd197c2-cf5e-42dc-9ccd-0c2adcaf4bc2'): {
+            "id": uuid.UUID('3cd197c2-cf5e-42dc-9ccd-0c2adcaf4bc2'),
+            'type': 'C'
+        }
     }
     assert populated_graph.get_nodes() == output
 
@@ -104,7 +113,12 @@ def test_get_node_attribute(populated_graph):
         populated_graph.get_node_attribute('3caaa8c09148493dbdf02c57deadbeef', 'type')
 
 def test_get_node_attributes(populated_graph):
-    assert populated_graph.get_node_attributes('3caaa8c09148493dbdf02c574b95526c') == {"type": "A"}
+    assert ( populated_graph.get_node_attributes('3caaa8c09148493dbdf02c574b95526c') == 
+        {
+            "id": uuid.UUID('3caaa8c0-9148-493d-bdf0-2c574b95526c'),
+            'type': 'A'
+        }
+    )
     with pytest.raises(sn.GraphException):
         populated_graph.get_node_attributes('3caaa8c09148493dbdf02c57deadbeef')
 


### PR DESCRIPTION
- Allow string input on all methods that take an id for input. User shouldn't have to import `uuid` to specify an ID manually.
- Add `remove_node()` and `remove_edge()`
- Add unit tests using the `pytest` module.
