### PR TITLE
Split Graph and DiGraph

### DIFF
--- a/DiGraph.py
+++ b/DiGraph.py
@@ -1,0 +1,31 @@
+import networkx as nx
+from semanticnet import Graph
+
+class DiGraph(Graph):
+
+    def __init__(self, verbose=False):
+        self._g = nx.MultiDiGraph()
+        self._edges = {}
+        self.meta = {}
+        self.timeline = []
+
+        self.verbose = verbose
+        self.attr_reserved = ["id", "src", "dst"]
+
+    def remove_node(self, id_):
+        '''Removes node id_.'''
+        id_ = self._extract_uuid(id_)
+        if self._g.has_node(id_):
+            # for DiGraph, remove predecessors AND successors
+            for successor in self._g.neighbors(id_):
+                # need to iterate over items() (which copies the dict) because we are
+                # removing items from the edges dict as we are iterating over it
+                for edge in self._g.edge[id_][successor].items():
+                    self.remove_edge(self._g.edge[id_][successor][edge[0]]["id"]) # edge[0] is the edge's ID
+            for predecessor in self._g.predecessors(id_):
+                for edge in self._g.edge[predecessor][id_].items():
+                    self.remove_edge(self._g.edge[predecessor][id_][edge[0]]["id"])
+
+            self._g.remove_node(id_)
+        else:
+            raise GraphException("Node ID not found.")

--- a/DiGraph.py
+++ b/DiGraph.py
@@ -4,13 +4,8 @@ from semanticnet import Graph
 class DiGraph(Graph):
 
     def __init__(self, verbose=False):
+        super(DiGraph, self).__init__()
         self._g = nx.MultiDiGraph()
-        self._edges = {}
-        self.meta = {}
-        self.timeline = []
-
-        self.verbose = verbose
-        self.attr_reserved = ["id", "src", "dst"]
 
     def remove_node(self, id_):
         '''Removes node id_.'''

--- a/Graph.py
+++ b/Graph.py
@@ -203,12 +203,8 @@ class Graph:
             graph["edges"] = [
                 dict(
                     chain(
-                        { "src": i.hex, "dst": j.hex, "id": key.hex}.items(),
-                        [ item for item in self._g.edge[i][j][key].items()
-                            if  item[0] != 'id' and
-                                item[0] != 'src' and
-                                item[0] != 'dst'
-                        ]
+                        self._g.edge[i][j][key].items(),
+                        { "src": i.hex, "dst": j.hex, "id": key.hex}.items()
                     )
                 )
                 for i, j in self._g.edges()

--- a/Graph.py
+++ b/Graph.py
@@ -13,13 +13,13 @@ class GraphException(Exception):
     def __str__(self):
         return repr(self.msg)
 
-class Event:
+class Event(object):
     def __init__(self, timecode, name, attributes):
         self.timecode = timecode
         self.name = name
         self.attributes = attributes
 
-class Graph:
+class Graph(object):
     '''A simple Graph structure which lets you focus on the data.'''
 
     def __init__(self, verbose=False):

--- a/Graph.py
+++ b/Graph.py
@@ -234,8 +234,8 @@ class Graph:
                 self.add_edge(
                     src,
                     dst,
-                    dict(item for item in edge.items()
-                        if (item[0] != "src" and item[0] != "dst" and item[0] != "id") ),
+                    dict([item for item in edge.items()
+                            if (item[0] != "src" and item[0] != "dst" and item[0] != "id")] ),
                     id_
                 )
                 self._g.edge[src][dst][id_]["id"] = id_

--- a/Graph.py
+++ b/Graph.py
@@ -134,6 +134,10 @@ class Graph(object):
         '''Returns a list of all nodes in the graph.'''
         return dict([ (id_, self._g.node[id_]) for id_ in self._g.nodes() ])
 
+    def get_node(self, id_):
+        id_ = self._extract_uuid(id_)
+        return self._g.node[id_]
+
     def get_node_attribute(self, id_, attr_name):
         '''Returns the attribute attr_name of node id_.'''
         id_ = self._extract_uuid(id_)

--- a/Graph.py
+++ b/Graph.py
@@ -1,6 +1,7 @@
 import networkx as nx
 import json
 import uuid
+import copy
 from itertools import chain
 
 class GraphException(Exception):
@@ -235,6 +236,9 @@ class Graph:
                     id_
                 )
                 self._g.edge[src][dst][id_]["id"] = id_
+
+    def networkx_graph(self):
+        return copy.deepcopy(self._g)
 
 if __name__ == "__main__":
     print("Please import this module !")

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ To build a graph out of a portion of your file system, run the example script `f
 ```
 
 This will build a tree out of your `~/src/python` folder save the file `fs.json` in your working directory.
-(Obviously, you can change the folder to any you would like to visualize). Then, to run the visualizer with this data:
+(Obviously, you can change the argument path to any you would like to visualize).
+Then, to run the visualizer with this data:
 
 ```sh
 cd gaia

--- a/README.md
+++ b/README.md
@@ -4,6 +4,75 @@ semantic-net
 Semantic-Net is a small python library to create semantic graphs in JSON.
 Those created datasets can then be visualized with the 3D graph engine.
 
+## JSON representation
+When saving graph objects as JSON, the graph is represented internally as one might expect.
+Suppose you have a graph G = (V,E), where 
+
+V = {0, 1, 2} and
+E = {(0, 1), (0, 2), (1, 2)}
+
+Suppose further that:
+
+1. Vertex 0 has the attributes: `{"type": "A", "id": 0}`
+2. Vertex 1 has the attributes: `{"type": "B", "id": 1}`
+3. Vertex 2 has the attributes: `{"type": "C", "id": 2}`
+4. Edge (0, 1) has the attributes: `{'src': 0, 'dst': 1, 'type': 'normal', 'id': 0}`
+5. Edge (0, 2) has the attributes: `{'src': 0, 'dst': 2, 'type': 'normal', 'id': 1}`
+6. Edge (1, 2) has the attributes: `{'src': 1, 'dst': 2, 'type': 'irregular', 'id': 1}`
+
+then in JSON format, it would look like:
+
+```json
+{
+ "timeline": [], 
+ "nodes": [
+  {
+   "type": "A", 
+   "id": 0
+  }, 
+  {
+   "type": "B", 
+   "id": 1
+  }, 
+  {
+   "type": "C", 
+   "id": 2
+  }
+ ], 
+ "meta": {}, 
+ "edges": [
+  {
+   "src": 0, 
+   "dst": 1, 
+   "type": "normal", 
+   "id": 0
+  }, 
+  {
+   "src": 0, 
+   "dst": 2, 
+   "type": "normal", 
+   "id": 1
+  }, 
+  {
+   "src": 1, 
+   "dst": 2, 
+   "type": "irregular", 
+   "id": 2
+  }
+ ]
+}
+```
+
+As you can see, there is a list of `"node"` objects, each of which contain the node's attributes and IDs,
+as well as a list of `"edge"` objects, each of which have the edge's attributes, and the fields `"src"` and `"dst"`,
+which indicate the source and destination vertices, respectively.
+
+In actuality, the `"id"` fields will be [UUIDs](http://en.wikipedia.org/wiki/Globally_unique_identifier).
+
+## Examples
+### File system
+
+
 ## Installation
 
 ### Dedpendencies

--- a/README.md
+++ b/README.md
@@ -71,7 +71,19 @@ In actuality, the `"id"` fields will be [UUIDs](http://en.wikipedia.org/wiki/Glo
 
 ## Examples
 ### File system
+To build a graph out of a portion of your file system, run the example script `fs_graph.py`:
 
+```sh
+./examples/fs_graph.py ~/src/python
+```
+
+This will build a tree out of your `~/src/python` folder save the file `fs.json` in your working directory.
+(Obviously, you can change the folder to any you would like to visualize). Then, to run the visualizer with this data:
+
+```sh
+cd gaia
+./gaia demo ../../semanticnet/fs.json
+```
 
 ## Installation
 

--- a/SemanticNet.py
+++ b/SemanticNet.py
@@ -22,7 +22,7 @@ class Graph:
     '''A simple Graph structure which lets you focus on the data.'''
 
     def __init__(self, verbose=False):
-        self._g = nx.MultiDiGraph()
+        self._g = nx.MultiGraph()
         self._edges = {}
         self.meta = {}
         self.timeline = []

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,2 @@
 from Graph import *
+from DiGraph import *

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-from SemanticNet import *
+from Graph import *

--- a/test/test_output_correct.json
+++ b/test/test_output_correct.json
@@ -17,21 +17,21 @@
  "meta": {}, 
  "edges": [
   {
-   "src": "d6523f4f9d5240d2a92e341f4ca00a78", 
-   "dst": "bcb388bb24a74d978fa2006ed278b2fe", 
-   "type": "owns", 
-   "id": "081369f6197b467abe97b3efe8cc4640"
-  }, 
-  {
-   "src": "d6523f4f9d5240d2a92e341f4ca00a78", 
-   "dst": "6cf546f71efe47578f7a1400871ef6b8", 
-   "type": "has", 
+   "src": "d6523f4f9d5240d2a92e341f4ca00a78",
+   "dst": "6cf546f71efe47578f7a1400871ef6b8",
+   "type": "has",
    "id": "b3a245098d5d482f893c6d63606c7e91"
   }, 
   {
-   "src": "bcb388bb24a74d978fa2006ed278b2fe", 
-   "dst": "6cf546f71efe47578f7a1400871ef6b8", 
-   "type": "belongs", 
+   "src": "bcb388bb24a74d978fa2006ed278b2fe",
+   "dst": "d6523f4f9d5240d2a92e341f4ca00a78",
+   "type": "owns",
+   "id": "081369f6197b467abe97b3efe8cc4640"
+  }, 
+  {
+   "src": "6cf546f71efe47578f7a1400871ef6b8",
+   "dst": "bcb388bb24a74d978fa2006ed278b2fe",
+   "type": "belongs",
    "id": "ff8a8a8093cf436aa3b0127c71ddc11d"
   }
  ]

--- a/test/test_semanticnet.py
+++ b/test/test_semanticnet.py
@@ -356,3 +356,17 @@ def test_load_json(correct_output_graph):
     }
 
     assert correct_output_graph.get_edges() == edges
+
+def test_networkx_graph(populated_graph):
+    nx_graph = populated_graph.networkx_graph()
+
+    # make sure all edges and nodes are the same
+    for id_, attr in populated_graph.get_edges().iteritems():
+        assert nx_graph.edge[attr["src"]][attr["dst"]][id_] == attr
+
+    for id_, attr in populated_graph.get_nodes().iteritems():
+        assert nx_graph.node[id_] == attr
+
+
+    # but that it is not the same object
+    assert nx_graph is not populated_graph._g

--- a/test/test_semanticnet.py
+++ b/test/test_semanticnet.py
@@ -1,8 +1,9 @@
 import pytest
-import semanticnet.SemanticNet as sn
+import semanticnet as sn
 import uuid
 import os
 import time
+import json
 
 ### FIXTURES ###
 @pytest.fixture
@@ -42,17 +43,17 @@ def test_output():
 
     graph.save_json("test_output.json")
 
-    f_str = ""
     with open("test_output.json") as f:
-        f_str = f.read()
-    return f_str
+        jsonObj = json.load(f)
+
+    return jsonObj
 
 @pytest.fixture
 def correct_output():
-    f_str = ""
     with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_output_correct.json")) as f:
-        f_str = f.read()
-    return f_str
+        jsonObj = json.load(f)
+
+    return jsonObj
 
 @pytest.fixture
 def correct_output_graph():
@@ -272,7 +273,20 @@ def test_remove_node(populated_graph):
         populated_graph.remove_node('3caaa8c09148493dbdf02c57deadbeef')
 
 def test_save_json(test_output, correct_output):
-    assert test_output == correct_output
+    assert test_output["timeline"] == correct_output["timeline"]
+    assert test_output["meta"] == correct_output["meta"]
+
+    for node in test_output["nodes"]:
+        assert node in correct_output["nodes"]
+
+    for edge in test_output["edges"]:
+        # for an undirected edge, reversing src and dst is valid
+        try:
+            assert edge in correct_output["edges"]
+        except AssertionError:
+            edge["src"], edge["dst"] = edge["dst"], edge["src"]
+            assert edge in correct_output["edges"]
+
     os.remove("test_output.json")
 
 def test_load_json(correct_output_graph):
@@ -286,8 +300,8 @@ def test_load_json(correct_output_graph):
 
     edges = {
         uuid.UUID('081369f6197b467abe97b3efe8cc4640'): {
-            'src': uuid.UUID('d6523f4f9d5240d2a92e341f4ca00a78'),
-            'dst': uuid.UUID('bcb388bb24a74d978fa2006ed278b2fe'),
+            'src': uuid.UUID('bcb388bb24a74d978fa2006ed278b2fe'),
+            'dst': uuid.UUID('d6523f4f9d5240d2a92e341f4ca00a78'),
             'type': 'owns',
             'id': uuid.UUID('081369f6197b467abe97b3efe8cc4640')
         },
@@ -298,8 +312,8 @@ def test_load_json(correct_output_graph):
             'id': uuid.UUID('b3a245098d5d482f893c6d63606c7e91')
         },
         uuid.UUID('ff8a8a8093cf436aa3b0127c71ddc11d'): {
-            'src': uuid.UUID('bcb388bb24a74d978fa2006ed278b2fe'),
-            'dst': uuid.UUID('6cf546f71efe47578f7a1400871ef6b8'),
+            'src': uuid.UUID('6cf546f71efe47578f7a1400871ef6b8'),
+            'dst': uuid.UUID('bcb388bb24a74d978fa2006ed278b2fe'),
             'type': 'belongs',
             'id': uuid.UUID('ff8a8a8093cf436aa3b0127c71ddc11d')
         }

--- a/test/test_semanticnet.py
+++ b/test/test_semanticnet.py
@@ -203,6 +203,15 @@ def test_get_edges(populated_graph):
     }
     assert populated_graph.get_edges() == output
 
+def test_get_node(populated_graph):
+    assert (
+        populated_graph.get_node('3caaa8c09148493dbdf02c574b95526c') ==
+        {
+            "type": "A",
+            "id": uuid.UUID('3caaa8c09148493dbdf02c574b95526c')
+        }
+    )
+
 def test_get_edge_attribute(populated_graph):
     assert populated_graph.get_edge_attribute('5f5f44ec7c0144e29c5b7d513f92d9ab', 'type') == 'normal'
 

--- a/test/test_semanticnet.py
+++ b/test/test_semanticnet.py
@@ -30,6 +30,18 @@ def populated_graph():
     return g
 
 @pytest.fixture
+def populated_digraph():
+    g = sn.DiGraph()
+    a = g.add_node({"type": "A"}, '3caaa8c09148493dbdf02c574b95526c')
+    b = g.add_node({"type": "B"}, '2cdfebf3bf9547f19f0412ccdfbe03b7')
+    c = g.add_node({"type": "C"}, '3cd197c2cf5e42dc9ccd0c2adcaf4bc2')
+    g.add_edge(a, b, {"type": "normal"}, '5f5f44ec7c0144e29c5b7d513f92d9ab')
+    g.add_edge(b, a, {"type": "normal"}, 'f3674fcc691848ebbd478b1bfb3e84c3')
+    g.add_edge(a, c, {"type": "normal"}, '7eb91be54d3746b89a61a282bcc207bb')
+    g.add_edge(b, c, {"type": "irregular"}, 'c172a3599b7d4ef3bbb688277276b763')
+    return g
+
+@pytest.fixture
 def test_output():
     graph = sn.Graph()
 
@@ -271,6 +283,30 @@ def test_remove_node(populated_graph):
 
     with pytest.raises(sn.GraphException):
         populated_graph.remove_node('3caaa8c09148493dbdf02c57deadbeef')
+
+def test_remove_digraph_node(populated_digraph):
+    node_a_id = uuid.UUID('3caaa8c09148493dbdf02c574b95526c')
+    node_b_id = uuid.UUID('2cdfebf3bf9547f19f0412ccdfbe03b7')
+    node_c_id = uuid.UUID('3cd197c2cf5e42dc9ccd0c2adcaf4bc2')
+
+    edge_a_b_id = uuid.UUID('5f5f44ec7c0144e29c5b7d513f92d9ab')
+    edge_b_a_id = uuid.UUID('f3674fcc691848ebbd478b1bfb3e84c3')
+    edge_a_c_id = uuid.UUID('7eb91be54d3746b89a61a282bcc207bb')
+    edge_b_c_id = uuid.UUID('c172a3599b7d4ef3bbb688277276b763')
+
+    populated_digraph.remove_node('3caaa8c09148493dbdf02c574b95526c')
+
+    # make sure a is gone, and b and c are not
+    assert node_a_id not in populated_digraph.get_nodes()
+    assert node_b_id in populated_digraph.get_nodes()
+    assert node_c_id in populated_digraph.get_nodes()
+
+    # make sure edges (a,b), (b,a), (a,c) are gone but (b,c) is not
+    edges = populated_digraph.get_edges()
+    assert edge_a_b_id not in edges
+    assert edge_b_a_id not in edges
+    assert edge_a_c_id not in edges
+    assert edge_b_c_id in edges
 
 def test_save_json(test_output, correct_output):
     assert test_output["timeline"] == correct_output["timeline"]


### PR DESCRIPTION
- Made another class `DiGraph`, which uses a networkx `MultiDiGraph` object, rather than a `MultiGraph` object.
- Fix some issues with the tests for `save_json()`
- Add a `networkx_graph()` method, which makes a deep copy of the underlying networkx graph.
- Add some documentation for the JSON representation and the filesystem example, per Andrew's request.
